### PR TITLE
Improve gedit language file

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,11 @@ If the option is defined (set to any value), the plugin will display more inform
 ### Tagbar
 [Tagbar](https://github.com/preservim/tagbar) is a Vim plugin that provides an easy way to browse the tags of the current file and get an overview of its structure. Follow steps in [Tagbar Wiki](https://github.com/preservim/tagbar/wiki#risc-v-asm) to apply it.
 
+## Gedit Syntax
+
+The repository includes a GtkSourceView language definition for RISC-V assembly highlighting in gedit. It builds on ideas from [riscv-asm-gedit](https://github.com/YohnWang/riscv-asm-gedit) and adds a larger instruction set from this plugin. Copy `gedit/riscv.lang` to your local `~/.local/share/gtksourceview-*/language-specs/` directory (create it if it does not exist) and restart gedit to enable the syntax.
+
+
 ## Contributing
 
 Contributions are welcome! If you encounter issues or have suggestions for improvements, please open an issue or submit a pull request on the [riscv-asm-vim](https://github.com/henry-hsieh/riscv-asm-vim).

--- a/gedit/riscv.lang
+++ b/gedit/riscv.lang
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<language id="riscv" _name="RISC-V Assembly" version="2.0" _section="Programming">
+  <metadata>
+    <property name="mimetypes">text/x-riscv</property>
+    <property name="globs">*.S;*.s</property>
+    <property name="line-comment-start">#</property>
+  </metadata>
+  <styles>
+    <style id="comment"      _name="Comment"      map-to="def:comment"/>
+    <style id="string"       _name="String"       map-to="def:string"/>
+    <style id="number"       _name="Number"       map-to="def:number"/>
+    <style id="instruction"  _name="Instruction"  map-to="def:keyword"/>
+    <style id="directive"    _name="Directive"    map-to="def:preprocessor"/>
+    <style id="register"     _name="Register"     map-to="def:type"/>
+    <style id="label"        _name="Label"        map-to="def:identifier"/>
+  </styles>
+  <definitions>
+    <context id="comment" style-ref="comment" end-at-line-end="true">
+      <start>#</start>
+    </context>
+    <context id="c-comment" style-ref="comment">
+      <start>/\*</start>
+      <end>\*/</end>
+    </context>
+    <context id="string" style-ref="string">
+      <start>"</start>
+      <end>"</end>
+      <escape>\\</escape>
+    </context>
+    <context id="string-single" style-ref="string">
+      <start>'</start>
+      <end>'</end>
+      <escape>\\</escape>
+    </context>
+    <context id="directive" style-ref="directive">
+      <match>\.[A-Za-z_\.]+</match>
+    </context>
+    <context id="label" style-ref="label">
+      <match>^[A-Za-z_.][A-Za-z0-9_.]*:</match>
+    </context>
+    <context id="register" style-ref="register">
+      <keyword>zero ra sp gp tp t0 t1 t2 t3 t4 t5 t6 fp</keyword>
+      <keyword>a0 a1 a2 a3 a4 a5 a6 a7</keyword>
+      <keyword>s0 s1 s2 s3 s4 s5 s6 s7 s8 s9 s10 s11</keyword>
+      <keyword>x0 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 x29 x30 x31</keyword>
+      <keyword>ft0 ft1 ft2 ft3 ft4 ft5 ft6 ft7 ft8 ft9 ft10 ft11 ft12 ft13 ft14 ft15 ft16 ft17 ft18 ft19 ft20 ft21 ft22 ft23 ft24 ft25 ft26 ft27 ft28 ft29 ft30 ft31</keyword>
+    </context>
+    <context id="instruction" style-ref="instruction">
+      <keyword>lui auipc jal jalr beq bne blt bge bltu bgeu</keyword>
+      <keyword>lb lh lw lbu lhu sb sh sw</keyword>
+      <keyword>addi slti sltiu xori ori andi slli srli srai</keyword>
+      <keyword>add sub sll slt sltu xor srl sra or and</keyword>
+      <keyword>fence fence.i fence.tso ecall ebreak</keyword>
+      <keyword>csrrw csrrs csrrc csrrwi csrrsi csrrci</keyword>
+      <keyword>mul mulh mulhsu mulhu div divu rem remu</keyword>
+      <keyword>flw fsw fadd.s fsub.s fmul.s fdiv.s fsqrt.s</keyword>
+      <keyword>fsgnj.s fsgnjn.s fsgnjx.s fmin.s fmax.s</keyword>
+      <keyword>fcvt.w.s fcvt.wu.s fmv.x.w feq.s flt.s fle.s fclass.s</keyword>
+      <keyword>fcvt.s.w fcvt.s.wu fmv.w.x</keyword>
+      <keyword>la lla lga nop li mv not neg negw sext.b sext.h sext.w zext.b zext.h zext.w</keyword>
+      <keyword>seqz snez sltz sgtz beqz bnez blez bgez bltz bgtz</keyword>
+      <keyword>bgt ble bgtu bleu j jr ret call tail</keyword>
+    </context>
+    <context id="numbers" style-ref="number">
+      <match>0[xX][0-9a-fA-F]+</match>
+      <match>0[bB][01]+</match>
+      <match>[0-9]+</match>
+    </context>
+    <context id="riscv">
+      <include>
+        <context ref="comment"/>
+        <context ref="c-comment"/>
+        <context ref="string"/>
+        <context ref="string-single"/>
+        <context ref="directive"/>
+        <context ref="label"/>
+        <context ref="register"/>
+        <context ref="instruction"/>
+        <context ref="numbers"/>
+      </include>
+    </context>
+  </definitions>
+  <patterns>
+    <include ref="riscv"/>
+  </patterns>
+</language>


### PR DESCRIPTION
## Summary
- expand instruction and register lists in `gedit/riscv.lang`
- add label highlighting and fix `mimetypes` property
- reference `riscv-asm-gedit` in README

## Testing
- `python3` XML validation on `gedit/riscv.lang`
